### PR TITLE
New representation for text regions: for each text region, creation of a <surface> element

### DIFF
--- a/xmlpage_to_tei.xsl
+++ b/xmlpage_to_tei.xsl
@@ -68,7 +68,9 @@
                             <xsl:value-of select="concat(//@imageHeight, 'px')"/>
                         </xsl:attribute>
                     </graphic>
-                    <xsl:apply-templates select="//pc:Page"/>
+                    <surfaceGrp>
+                        <xsl:apply-templates select="//pc:Page"/>
+                    </surfaceGrp>
                 </sourceDoc>
                 <text>
                     <body>


### PR DESCRIPTION
As stated in issue #4, a `<surface>` element alone, still grouping one or more `<zone>` representing baselines, is more appropriate and less redundant for representing a text region than using both `<surfaceGrp>` and `<surface>` for each of them.

`<surfaceGrp>` is now used to represent the image as a whole.