### PR TITLE
XSLT enhancements

### DIFF
--- a/xmlpage_to_tei.xsl
+++ b/xmlpage_to_tei.xsl
@@ -6,21 +6,21 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd"
     xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15">
-
+    
     <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
-
+    
     <xsl:template match="/">
-
+        
         <!-- Creation of a variable for storing file's name -->
         <xsl:variable name="file_name">
             <xsl:value-of select="replace(/pc:PcGts/pc:Page/@imageFilename, '.jpg', '')"/>
         </xsl:variable>
-
+        
         <!-- Creation of a variable for storing output file name -->
         <xsl:variable name="output_name">
             <xsl:value-of select="concat($file_name, '.tei.xml')"/>
         </xsl:variable>
-
+        
         <xsl:result-document href="{$output_name}" exclude-result-prefixes="xi xsi pc">
             <!-- teiHeader elements -->
             <TEI>
@@ -48,11 +48,11 @@
                     </fileDesc>
                     <revisionDesc>
                         <xsl:element name="change"><xsl:attribute name="when"><xsl:value-of
-                                    select="pc:PcGts/pc:Metadata/pc:Created"
-                            /></xsl:attribute>Creation</xsl:element>
+                            select="pc:PcGts/pc:Metadata/pc:Created"
+                        /></xsl:attribute>Creation</xsl:element>
                         <xsl:element name="change"><xsl:attribute name="when"><xsl:value-of
-                                    select="pc:PcGts/pc:Metadata/pc:LastChange"
-                            /></xsl:attribute>Last change</xsl:element>
+                            select="pc:PcGts/pc:Metadata/pc:LastChange"
+                        /></xsl:attribute>Last change</xsl:element>
                     </revisionDesc>
                 </teiHeader>
                 <sourceDoc>
@@ -98,34 +98,38 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:attribute>
-            <xsl:attribute name="points">
-                <xsl:value-of select="pc:Coords/@points"/>
-            </xsl:attribute>
-                <!-- For each <TextLine> in the PAGE XML, a <zone> element is created in the TEI. -->
-                <xsl:for-each select="pc:TextLine">
-                    <!-- <zone> in the TEI represents baseline's mask in the PAGE XML -->
-                    <xsl:element name="zone">
-                        <xsl:attribute name="xml:id">
-                            <xsl:value-of select="@id"/>
-                        </xsl:attribute>
-                        <xsl:attribute name="type"><xsl:value-of>mask</xsl:value-of></xsl:attribute>
+            <xsl:choose>
+                <xsl:when test="pc:Coords/@points">
+                    <xsl:attribute name="points">
+                        <xsl:value-of select="pc:Coords/@points"/>
+                    </xsl:attribute>
+                </xsl:when>
+            </xsl:choose>
+            <!-- For each <TextLine> in the PAGE XML, a <zone> element is created in the TEI. -->
+            <xsl:for-each select="pc:TextLine">
+                <!-- <zone> in the TEI represents baseline's mask in the PAGE XML -->
+                <xsl:element name="zone">
+                    <xsl:attribute name="xml:id">
+                        <xsl:value-of select="@id"/>
+                    </xsl:attribute>
+                    <xsl:attribute name="type"><xsl:value-of>mask</xsl:value-of></xsl:attribute>
+                    <xsl:attribute name="points">
+                        <xsl:value-of select="pc:Coords/@points"/>
+                    </xsl:attribute>
+                    <!-- <path> in the TEI represents baseline's coordinates -->
+                    <xsl:element name="path">
+                        <xsl:attribute name="type"><xsl:value-of>baseline</xsl:value-of></xsl:attribute>
                         <xsl:attribute name="points">
-                            <xsl:value-of select="pc:Coords/@points"/>
+                            <xsl:value-of select="pc:Baseline/@points"/>
                         </xsl:attribute>
-                        <!-- <path> in the TEI represents baseline's coordinates -->
-                        <xsl:element name="path">
-                            <xsl:attribute name="type"><xsl:value-of>baseline</xsl:value-of></xsl:attribute>
-                            <xsl:attribute name="points">
-                                <xsl:value-of select="pc:Baseline/@points"/>
-                            </xsl:attribute>
-                        </xsl:element>
-                        <!-- <line> element in the TEI represents the transcription in the PAGE XML -->
-                            <xsl:element name="line">
-                                <xsl:value-of select="pc:TextEquiv/pc:Unicode"/>
-                            </xsl:element>
                     </xsl:element>
-                </xsl:for-each>
+                    <!-- <line> element in the TEI represents the transcription in the PAGE XML -->
+                    <xsl:element name="line">
+                        <xsl:value-of select="pc:TextEquiv/pc:Unicode"/>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:for-each>
         </xsl:element>
     </xsl:template>
-
+    
 </xsl:stylesheet>

--- a/xmlpage_to_tei.xsl
+++ b/xmlpage_to_tei.xsl
@@ -91,7 +91,7 @@
             <xsl:attribute name="type">
                 <xsl:choose>
                     <xsl:when test="@custom">
-                        <xsl:value-of select="replace(@custom, ' ', '_')"/>
+                        <xsl:value-of select="replace(replace(@custom, 'structure \{type:', ''), ';\}', '')"/>
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:value-of>none</xsl:value-of>


### PR DESCRIPTION
Type attribute values are now simplified, and `<textRegion>` elements without nested `<coords>` are now handled.

See issues #14 and #15. 